### PR TITLE
Implement minimal crypto tax backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# cryptoDeclare
+# Crypto Declare
+
+Prototype web service for calculating Swedish crypto taxes.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set required environment variables:
+   ```bash
+   export ETHERSCAN_API_KEY=<your key>
+   ```
+3. Run the application:
+   ```bash
+   python app.py
+   ```
+
+API calls and calculations are logged in `logg.md`.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,49 @@
+"""Flask application exposing minimal crypto tax endpoints."""
+
+import os
+from flask import Flask, request, jsonify, render_template
+
+from data import fetch_transactions, calculate_tax
+from logger import log_run, log_divider
+
+app = Flask(__name__)
+
+# In-memory store for wallets in current session
+wallets = []
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/add_address', methods=['POST'])
+def add_address():
+    data = request.get_json()
+    address = data.get('address')
+    chain = data.get('chain', 'ethereum')
+    wallets.append({'address': address, 'chain': chain})
+    log_run(f"Address added: {address} on {chain}")
+    return jsonify({'status': 'ok', 'wallets': wallets})
+
+
+@app.route('/fetch_transactions', methods=['POST'])
+def fetch_txs():
+    results = []
+    for wallet in wallets:
+        txs = fetch_transactions(wallet['address'], wallet['chain'])
+        results.append({'address': wallet['address'], 'transactions': txs})
+    log_run(f"Fetched transactions for {len(wallets)} addresses")
+    return jsonify(results)
+
+
+@app.route('/calculate', methods=['POST'])
+def calculate():
+    report = calculate_tax(wallets)
+    log_run("Tax calculation requested")
+    log_divider()
+    return jsonify(report)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/data.py
+++ b/data.py
@@ -1,0 +1,68 @@
+"""Data access and tax calculation utilities."""
+
+import os
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+
+import requests
+
+from logger import log_run
+
+ETHERSCAN_API_KEY = os.getenv("ETHERSCAN_API_KEY", "")
+COINGECKO_URL = "https://api.coingecko.com/api/v3"
+
+
+def fetch_transactions(address: str, chain: str = "ethereum") -> List[Dict[str, Any]]:
+    """Retrieve transactions for a given wallet address."""
+    if chain != "ethereum":
+        raise ValueError("Only Ethereum is currently supported")
+
+    url = "https://api.etherscan.io/api"
+    params = {
+        "module": "account",
+        "action": "txlist",
+        "address": address,
+        "startblock": 0,
+        "endblock": 99999999,
+        "sort": "asc",
+        "apikey": ETHERSCAN_API_KEY,
+    }
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        log_run(f"Etherscan API called for {address}")
+        return data.get("result", [])
+    except Exception as exc:
+        log_run(f"Etherscan API error: {exc}")
+        return []
+
+
+def get_price_in_sek(coin_id: str, date: datetime) -> Optional[float]:
+    """Fetch historical price in SEK from CoinGecko."""
+    url = f"{COINGECKO_URL}/coins/{coin_id}/history"
+    params = {"date": date.strftime("%d-%m-%Y"), "localization": "false"}
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        price = data["market_data"]["current_price"]["sek"]
+        log_run(f"CoinGecko price fetched for {coin_id} on {date.date()}")
+        return price
+    except Exception as exc:
+        log_run(f"CoinGecko API error: {exc}")
+        return None
+
+
+def calculate_tax(wallets: List[Dict[str, str]]) -> List[Dict[str, Any]]:
+    """Placeholder tax calculation using transaction count."""
+    report = []
+    for wallet in wallets:
+        txs = fetch_transactions(wallet["address"], wallet["chain"])
+        entry = {
+            "address": wallet["address"],
+            "total_transactions": len(txs),
+        }
+        report.append(entry)
+    log_run("Tax calculation executed (placeholder)")
+    return report

--- a/logg.md
+++ b/logg.md
@@ -1,0 +1,3 @@
+# Execution Log
+
+---

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,19 @@
+"""Utility for appending execution logs to logg.md."""
+
+from datetime import datetime
+
+LOG_FILE = "logg.md"
+
+
+def log_run(message: str) -> None:
+    """Append a timestamped message to the log file."""
+    timestamp = datetime.utcnow().isoformat()
+    entry = f"### {timestamp}\n- {message}\n\n"
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(entry)
+
+
+def log_divider() -> None:
+    """Add a divider for readability between runs."""
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write("---\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Crypto Declarer</title>
+</head>
+<body>
+    <h1>Crypto Declarer</h1>
+    <form id="addForm">
+        <label>Wallet Address: <input type="text" id="address" /></label>
+        <label>Chain:
+            <select id="chain">
+                <option value="ethereum">Ethereum</option>
+            </select>
+        </label>
+        <button type="submit">Add Address</button>
+    </form>
+    <button onclick="fetchTx()">Fetch Transactions</button>
+    <button onclick="calc()">Calculate</button>
+    <pre id="output"></pre>
+<script>
+    document.getElementById('addForm').addEventListener('submit', async ev => {
+        ev.preventDefault();
+        const address = document.getElementById('address').value;
+        const chain = document.getElementById('chain').value;
+        const res = await fetch('/add_address', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({address, chain})
+        });
+        const data = await res.json();
+        document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+    });
+    async function fetchTx() {
+        const res = await fetch('/fetch_transactions', {method: 'POST'});
+        const data = await res.json();
+        document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+    }
+    async function calc() {
+        const res = await fetch('/calculate', {method: 'POST'});
+        const data = await res.json();
+        document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+    }
+</script>
+</body>
+</html>

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,0 +1,4 @@
+"""Trivial test to ensure pytest runs."""
+
+def test_dummy():
+    assert True


### PR DESCRIPTION
## Summary
- add Flask backend with endpoints for adding addresses, fetching transactions and calculating tax
- fetch data from Etherscan and CoinGecko (placeholder calculations)
- log each action in `logg.md` via `logger.py`
- provide simple HTML frontend
- include requirements and README instructions
- add trivial pytest test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f033c2cfc83338d989b413ab8ebf5