### PR TITLE
Add Solana support and tax calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Crypto Declare
 
 Prototype web service for calculating Swedish crypto taxes.
+Ethereum and Solana wallets are supported.
 
 ## Setup
 

--- a/data.py
+++ b/data.py
@@ -14,27 +14,30 @@ COINGECKO_URL = "https://api.coingecko.com/api/v3"
 
 def fetch_transactions(address: str, chain: str = "ethereum") -> List[Dict[str, Any]]:
     """Retrieve transactions for a given wallet address."""
-    if chain != "ethereum":
-        raise ValueError("Only Ethereum is currently supported")
-
-    url = "https://api.etherscan.io/api"
-    params = {
-        "module": "account",
-        "action": "txlist",
-        "address": address,
-        "startblock": 0,
-        "endblock": 99999999,
-        "sort": "asc",
-        "apikey": ETHERSCAN_API_KEY,
-    }
+    if chain == "ethereum":
+        url = "https://api.etherscan.io/api"
+        params = {
+            "module": "account",
+            "action": "txlist",
+            "address": address,
+            "startblock": 0,
+            "endblock": 99999999,
+            "sort": "asc",
+            "apikey": ETHERSCAN_API_KEY,
+        }
+    elif chain == "solana":
+        url = "https://api.solscan.io/account/transactions"
+        params = {"address": address}
+    else:
+        raise ValueError("Unsupported chain")
     try:
         response = requests.get(url, params=params, timeout=10)
         response.raise_for_status()
         data = response.json()
-        log_run(f"Etherscan API called for {address}")
+        log_run(f"{chain.capitalize()} API called for {address}")
         return data.get("result", [])
     except Exception as exc:
-        log_run(f"Etherscan API error: {exc}")
+        log_run(f"{chain.capitalize()} API error: {exc}")
         return []
 
 
@@ -54,15 +57,62 @@ def get_price_in_sek(coin_id: str, date: datetime) -> Optional[float]:
         return None
 
 
+def process_transactions(transactions: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Compute gains and losses using the average cost method."""
+    holdings: Dict[str, Dict[str, float]] = {}
+    events: List[Dict[str, Any]] = []
+    totals: Dict[str, float] = {}
+
+    txs = sorted(transactions, key=lambda t: t.get("timestamp", 0))
+    for tx in txs:
+        cur = tx.get("currency")
+        if not cur:
+            log_run("Transaction missing currency field")
+            continue
+        holdings.setdefault(cur, {"qty": 0.0, "cost": 0.0})
+        totals.setdefault(cur, 0.0)
+        h = holdings[cur]
+        typ = tx.get("type", "unknown").lower()
+        qty = float(tx.get("amount", 0))
+        sek_value = float(tx.get("sek_value", 0))
+
+        if typ in {"buy", "incoming", "airdrop", "receive", "swap_in"}:
+            h["qty"] += qty
+            h["cost"] += sek_value
+        elif typ in {"sell", "payment", "swap_out", "fee"}:
+            avg = h["cost"] / h["qty"] if h["qty"] else 0
+            cost_basis = avg * qty
+            gain = sek_value - cost_basis
+            events.append({
+                "date": tx.get("timestamp"),
+                "quantity": qty,
+                "currency": cur,
+                "selling_price": sek_value,
+                "cost_basis": cost_basis,
+                "gain_loss": gain,
+                "hash": tx.get("tx_hash"),
+            })
+            totals[cur] += gain
+            h["qty"] -= qty
+            h["cost"] -= cost_basis
+        else:
+            log_run(f"Unknown tx type: {typ}")
+
+    summary = [{"currency": c, "gain_loss": round(v, 2)} for c, v in totals.items()]
+    return {"events": events, "summary": summary}
+
+
 def calculate_tax(wallets: List[Dict[str, str]]) -> List[Dict[str, Any]]:
-    """Placeholder tax calculation using transaction count."""
+    """Calculate tax reports for provided wallets."""
     report = []
     for wallet in wallets:
         txs = fetch_transactions(wallet["address"], wallet["chain"])
+        processed = process_transactions(txs)
         entry = {
             "address": wallet["address"],
-            "total_transactions": len(txs),
+            "events": processed["events"],
+            "summary": processed["summary"],
         }
         report.append(entry)
-    log_run("Tax calculation executed (placeholder)")
+    log_run("Tax calculation executed")
     return report

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,7 @@
         <label>Chain:
             <select id="chain">
                 <option value="ethereum">Ethereum</option>
+                <option value="solana">Solana</option>
             </select>
         </label>
         <button type="submit">Add Address</button>

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -1,0 +1,17 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from data import process_transactions
+
+
+def test_process_transactions_example():
+    txs = [
+        {"timestamp": 1, "type": "buy", "currency": "DOGE", "amount": 10, "sek_value": 10000, "tx_hash": "a"},
+        {"timestamp": 2, "type": "buy", "currency": "DOGE", "amount": 10, "sek_value": 50000, "tx_hash": "b"},
+        {"timestamp": 3, "type": "sell", "currency": "DOGE", "amount": 15, "sek_value": 60000, "tx_hash": "c"},
+        {"timestamp": 4, "type": "buy", "currency": "DOGE", "amount": 5, "sek_value": 25000, "tx_hash": "d"},
+    ]
+    result = process_transactions(txs)
+    summary = result["summary"][0]
+    assert summary["currency"] == "DOGE"
+    assert round(summary["gain_loss"], 2) == 15000


### PR DESCRIPTION
## Summary
- support Solana when fetching transactions and in the web form
- implement tax calculation using Swedish average cost method
- document Solana support in README
- include unit test for tax algorithm

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0842fb18833384376454bee1810d